### PR TITLE
Fix https://github.com/quiqueck/BCLib/issues/146

### DIFF
--- a/wover-event-api/src/main/java/org/betterx/wover/state/impl/WorldConfigImpl.java
+++ b/wover-event-api/src/main/java/org/betterx/wover/state/impl/WorldConfigImpl.java
@@ -45,7 +45,7 @@ public class WorldConfigImpl {
 
     @ApiStatus.Internal
     public static void initialize() {
-        WorldLifecycle.WORLD_FOLDER_READY.subscribe(WorldConfigImpl::loadForWorld);
+        WorldLifecycle.WORLD_FOLDER_READY.subscribe(WorldConfigImpl::loadForWorld, 10100);
         registerMod(ModCoreImpl.GLOBAL_MOD);
         registerMod(LegacyHelper.BCLIB_CORE);
         registerMod(LegacyHelper.WORLDS_TOGETHER_CORE);


### PR DESCRIPTION
Loading world configs should be done before BCLib tries patching the world as it needs the config to decide if the mod has been updated. When the config isn't loaded, it will always think that the mod has been updated.