### PR TITLE
Return actual genChance for wover biomes

### DIFF
--- a/wover-generator-api/src/main/java/org/betterx/wover/generator/api/biomesource/WoverBiomeData.java
+++ b/wover-generator-api/src/main/java/org/betterx/wover/generator/api/biomesource/WoverBiomeData.java
@@ -249,6 +249,11 @@ public class WoverBiomeData extends BiomeData {
         return parent == null && findEdgeParent() == null;
     }
 
+    @Override
+    public float genChance(){
+        return this.genChance;
+    }
+
     public BiomeData getEdgeData() {
         if (edgeData == null) return null;
         final Registry<BiomeData> reg = getDataRegistry("edge biome", biomeKey);


### PR DESCRIPTION
`WoverBiomeData` class doesn't override `public float genChance()` from its base class. The base class returns 1.0f by default, which results in world weaver completely ignoring genChance.